### PR TITLE
feat: e.g simple Azion cookies library

### DIFF
--- a/examples/javascript/simple-js-cookies/.gitignore
+++ b/examples/javascript/simple-js-cookies/.gitignore
@@ -1,0 +1,25 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+.env
+azion
+.edge

--- a/examples/javascript/simple-js-cookies/README.md
+++ b/examples/javascript/simple-js-cookies/README.md
@@ -1,0 +1,47 @@
+# Simple js Cookies
+
+Simple Example of how to use cookies in JavaScript, using the 'azion/cookies' library
+
+### Usage:
+
+Install dependencies:
+
+```bash
+
+npm install
+
+```
+
+Run the build command:
+
+```bash
+
+npx edge-functions@latest build --preset javascript --mode deliver
+
+```
+
+Run the dev command:
+
+```bash
+
+npx edge-functions@latest dev
+
+```
+
+If everything goes as expected, the application runs successfully.
+
+Open in the browser or execute the command:
+
+```bash
+
+curl --location --request GET 'http://localhost:<port>'
+
+```
+
+The answer will be:
+
+```text
+
+Hello, Cookies 🍪!
+
+```

--- a/examples/javascript/simple-js-cookies/main.js
+++ b/examples/javascript/simple-js-cookies/main.js
@@ -1,0 +1,17 @@
+/* eslint-disable */
+import { getCookie, setCookie } from "azion/cookies";
+
+export default async function main(event) {
+  const cookieKey = "auth";
+  const cookie = getCookie(event.request, cookieKey);
+  const response = new Response("Hello, Cookies 🍪!", { status: 200 });
+  if (!cookie) {
+    try {
+      console.log("Setting cookie 🍪🍪🍪");
+      setCookie(response, cookieKey, "123", { maxAge: 30 });
+    } catch (e) {
+      console.error(e);
+    }
+  }
+  return response;
+}

--- a/examples/javascript/simple-js-cookies/package.json
+++ b/examples/javascript/simple-js-cookies/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "simple-js-cookies",
+  "version": "1.0.0",
+  "description": "Simple Example of how to use cookies in JavaScript, using the 'azion/cookies' library",
+  "main": "main.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "aziontech",
+  "license": "ISC",
+  "dependencies": {
+    "azion": "latest"
+  }
+}

--- a/examples/javascript/simple-js-cookies/vulcan.config.js
+++ b/examples/javascript/simple-js-cookies/vulcan.config.js
@@ -1,0 +1,7 @@
+export default {
+  entry: "main.js",
+  preset: {
+    name: "javascript",
+    mode: "compute",
+  },
+};


### PR DESCRIPTION
Adding a simple example of using the cookies package from the Azion library (azion/cookies).

> Instructions in the example README.md

`Important:`

Check if version 1.2.0 (or 1.2.0.stage.x) of the library has already been published.

If it has not been published, it is necessary to clone the library and perform the `npm link` for local testing.